### PR TITLE
White Space on Right Side of Pages in many other device types #310

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,10 @@
   box-sizing: border-box;
 }
 
+html, body {
+  overflow-x: hidden;
+  width: 100%;
+}
 
 /* Styles for light mode */
 .light-mode-app {


### PR DESCRIPTION
### Description:

There is an issue with the layout of our application where a significant amount of white space appears on the right side of the page, particularly noticeable on various devices and screen sizes. This problem disrupts the user experience by introducing unnecessary horizontal scrolling.

so I fixed this adding some style.

### Screenshots

with issue -
![image](https://github.com/abhay-raj19/FitBody/assets/115466381/66de5cf3-3e0d-4519-b48e-0c4500d6a112)


after resolving issue -

![image](https://github.com/abhay-raj19/FitBody/assets/115466381/7b30136a-c75e-4f0f-8243-b77105344a2e)


### Other information

- [ X] I have performed a self-review of my code
- [ X] I have read and followed the Contribution Guidelines.
- [ X] I have tested the changes thoroughly before submitting this pull request.
- [X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X ] I have commented my code, particularly in hard-to-understand areas.
